### PR TITLE
fix: reference path definition

### DIFF
--- a/__tests__/reference.spec.ts
+++ b/__tests__/reference.spec.ts
@@ -2,11 +2,13 @@ import { firestore, reference } from '../src/reference'
 
 describe('reference', () => {
   describe('refefrence', () => {
-    it('create reference', () => {
-      const fs = firestore({ projectId: 'project' }, { fetch: jest.fn() })
-
-      const ref = reference(fs, 'collection', 'document')
-
+    const fs = firestore({ projectId: 'project' }, { fetch: jest.fn() })
+  
+    it.each([
+      { ref: reference(fs, '/collection/document') },
+      { ref: reference(fs, 'collection', 'document') },
+      { ref: reference(fs, 'collection/document') },
+    ])('create refefence', ({ ref }) => {
       expect(ref.id).toEqual('document')
       expect(ref.parent.id).toEqual('collection')
     })

--- a/src/reference.ts
+++ b/src/reference.ts
@@ -39,12 +39,14 @@ export interface Reference {
 }
 
 export function reference(firestore: Firestore, path: string, ...paths: string[]): Reference {
-  let p = `${firestore.path}/${path}`
+  let p = firestore.path
+  if (path.startsWith('/')) p += path
+  else p += `/${path}`
+
   if (paths.length > 0) p += '/' + paths.join('/')
 
-  const id = paths.length === 0 ? path : paths[paths.length - 1]
-
   const ps = p.split('/')
+  const id = ps[ps.length - 1]
   return {
     get path(): string {
       return p

--- a/src/request.ts
+++ b/src/request.ts
@@ -59,7 +59,6 @@ export function buildRequest(firestore: Firestore, transactionId?: string): Requ
     forQuery(reference: Reference, query: Query): Parameters<typeof fetch> {
       const { path, id } = reference
       const index = path.lastIndexOf(id)
-      console.log(index)
       const p = `${path.substring(0, index)}:runQuery`
       const init: RequestInit = {
         method: 'post',

--- a/src/request.ts
+++ b/src/request.ts
@@ -59,6 +59,7 @@ export function buildRequest(firestore: Firestore, transactionId?: string): Requ
     forQuery(reference: Reference, query: Query): Parameters<typeof fetch> {
       const { path, id } = reference
       const index = path.lastIndexOf(id)
+      console.log(index)
       const p = `${path.substring(0, index)}:runQuery`
       const init: RequestInit = {
         method: 'post',


### PR DESCRIPTION
### Before

```ts
const fs = firestore({ /** ... */ })
const ref = reference(fs, '/collection/document') // Error!!
```

### After

```ts
const fs = firestore({ /** ... */ })
const ref = reference(fs, '/collection/document') // OK!
```